### PR TITLE
JDK Migration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM gradle:6.6-jdk11 AS build
 COPY ./ .
 RUN ./gradlew clean build dockerPrepare
 
-FROM openjdk:12-alpine
+FROM adoptopenjdk/openjdk11:alpine
 ENV RABBITMQ_HOST=rabbitmq \
     RABBITMQ_PORT=5672 \
     RABBITMQ_USER=guest \


### PR DESCRIPTION
[TH2-1261] Migrate Java components to the docker image with LTS java version adoptopenjdk/openjdk11:alpine
https://hub.docker.com/r/adoptopenjdk/openjdk11/