### PR TITLE
JDK downgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM gradle:7.6-jdk11 AS build
 COPY ./ .
 RUN ./gradlew clean build dockerPrepare
 
-FROM openjdk:12-alpine
+FROM openjdk:11-alpine
 ENV RABBITMQ_HOST=rabbitmq \
     RABBITMQ_PORT=5672 \
     RABBITMQ_USER=guest \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM gradle:7.6-jdk11 AS build
 COPY ./ .
 RUN ./gradlew clean build dockerPrepare
 
-FROM openjdk:11-alpine
+FROM adoptopenjdk/openjdk11:alpine
 ENV RABBITMQ_HOST=rabbitmq \
     RABBITMQ_PORT=5672 \
     RABBITMQ_USER=guest \

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ If the income message is correct (``NewOrderSingle``), the rule will generate on
 ## Release notes
 
 ### 4.0.0
+
++ JDK downgrade to v11
+
+### 4.0.0
 + Update `kotlin.jvm` to `1.8.22`
 + Added `kotlin_version`, `sim_version` and `common_version` to `gradle.properties`
 + Migration to books/pages cradle 5.1.1

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If the income message is correct (``NewOrderSingle``), the rule will generate on
 
 ## Release notes
 
-### 4.0.0
+### 4.0.1
 
 + JDK downgrade to v11
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-release_version=4.0.0
+release_version=4.0.1
 grpc_suffix=template
 kotlin_version=1.8.22
 sim_version=7.0.0-dev

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,5 +17,5 @@ release_version=4.0.1
 grpc_suffix=template
 kotlin_version=1.8.22
 sim_version=7.0.0-dev
-common_version=5.6.0-dev
+common_version=5.7.1-dev
 common_utils_version=2.2.2-dev


### PR DESCRIPTION
The JDK 12 causes a JVM crash when the application starts. There is no such problem with JDK 11. So, we change the base image version